### PR TITLE
Add pytest configuration for test discovery

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
## Summary
- add pytest.ini to point pytest at the `tests` directory

## Testing
- `pytest -q` *(fails: cannot import name 'mutual_info' from 'itpu.sdk')*

------
https://chatgpt.com/codex/tasks/task_e_68c6dd5f10d4832c8c8fb7d2b845cbfd