### PR TITLE
Remove top-level mutual_info re-export

### DIFF
--- a/itpu/__init__.py
+++ b/itpu/__init__.py
@@ -6,7 +6,7 @@ Software SDK for entropy, mutual information, and k-NN statistics.
 
 __version__ = "0.1.0"
 
-from .sdk import ITPU, mutual_info
+from .sdk import ITPU
 from .utils.windowed import windowed_mi
 
-__all__ = ["ITPU", "mutual_info", "windowed_mi"]
+__all__ = ["ITPU", "windowed_mi"]


### PR DESCRIPTION
## Summary
- drop mutual_info from itpu.__init__ to avoid package-level re-export

## Testing
- `PYTHONPATH=$PWD python scripts/smoke_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6e654197c832c9316e212d3bb837b