### PR TITLE
Scaffold itpu/stats/ module with stub implementations

### DIFF
--- a/itpu/stats/__init__.py
+++ b/itpu/stats/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .surrogate_test import surrogate_test
+
+__all__ = ["surrogate_test"]

--- a/itpu/stats/multiple_testing.py
+++ b/itpu/stats/multiple_testing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def benjamini_hochberg(
+    p_values: np.ndarray,
+    alpha: float = 0.05,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Apply the Benjamini-Hochberg procedure to control the false discovery rate.
+
+    Ranks p-values in ascending order and compares each against the BH
+    critical value (rank / m) * alpha, where m is the total number of tests.
+    All hypotheses up to and including the largest rank that satisfies the
+    criterion are rejected.
+
+    Parameters
+    ----------
+    p_values:
+        1D array of raw p-values, one per hypothesis.
+    alpha:
+        Target false discovery rate (FDR) level. Must be in (0, 1).
+
+    Returns
+    -------
+    corrected_p : np.ndarray
+        BH-adjusted p-values (same length as p_values), computed as
+        p * m / rank so that reject = corrected_p <= alpha.
+    reject : np.ndarray of bool
+        True for each hypothesis that is rejected at the given FDR level.
+    """
+    raise NotImplementedError

--- a/itpu/stats/surrogate_test.py
+++ b/itpu/stats/surrogate_test.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def surrogate_test(
+    x,
+    y,
+    method: str = "ksg",
+    n_surrogates: int = 1000,
+    surrogate_type: str = "shuffle",
+    fdr_alpha: float = 0.05,
+) -> dict[str, Any]:
+    """Test for statistical dependence between x and y using surrogate resampling.
+
+    Estimates mutual information between x and y with the chosen MI estimator,
+    then builds a null distribution by computing MI between x and n_surrogates
+    surrogate copies of y (generated via surrogate_type). The empirical p-value
+    is the fraction of null MI values >= the observed MI.
+
+    Optionally applies Benjamini-Hochberg FDR correction when called in a
+    multi-test context (reserved for future batch interface; fdr_alpha is
+    stored in the returned dict for downstream use).
+
+    Parameters
+    ----------
+    x:
+        1D array, first variable.
+    y:
+        1D array, second variable. Must be the same length as x.
+    method:
+        MI estimator to use. Currently supported: "ksg".
+    n_surrogates:
+        Number of surrogate samples used to build the null distribution.
+    surrogate_type:
+        Resampling strategy for generating surrogates. One of:
+        "shuffle" (independent permutation) or "block" (block bootstrap).
+    fdr_alpha:
+        FDR level passed to benjamini_hochberg() for downstream correction.
+        Not applied internally to the single-test p-value.
+
+    Returns
+    -------
+    dict with keys:
+        mi_observed : float
+            MI estimate (nats) between x and y.
+        null_distribution : np.ndarray, shape (n_surrogates,)
+            MI values computed under the null (x independent of shuffled y).
+        p_value : float
+            Empirical p-value: fraction of null MI >= mi_observed.
+        power_estimate : float
+            Estimated statistical power based on the separation between
+            mi_observed and the null distribution (heuristic, [0, 1]).
+        warnings : list[str]
+            Any diagnostic messages raised during estimation (e.g. from
+            ksg_mi_estimate) collected and surfaced here.
+    """
+    raise NotImplementedError

--- a/itpu/stats/surrogates.py
+++ b/itpu/stats/surrogates.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.random import Generator
+
+
+def shuffle_surrogate(
+    x: np.ndarray,
+    n_surrogates: int,
+    rng: Generator | None = None,
+) -> np.ndarray:
+    """Generate surrogates by independently shuffling x.
+
+    Each surrogate is a random permutation of the input array, destroying
+    any temporal or spatial structure while preserving the marginal
+    distribution.
+
+    Parameters
+    ----------
+    x:
+        1D input array to shuffle.
+    n_surrogates:
+        Number of surrogate samples to generate.
+    rng:
+        NumPy random Generator for reproducibility. If None, uses
+        numpy.random.default_rng().
+
+    Returns
+    -------
+    np.ndarray
+        Shape (n_surrogates, len(x)). Each row is one shuffled surrogate.
+    """
+    raise NotImplementedError
+
+
+def block_bootstrap_surrogate(
+    x: np.ndarray,
+    block_size: int,
+    n_surrogates: int,
+    rng: Generator | None = None,
+) -> np.ndarray:
+    """Generate surrogates via circular block bootstrap.
+
+    Resamples contiguous blocks of x with replacement, preserving short-range
+    autocorrelation structure while breaking long-range dependence with y.
+    Uses circular (wrap-around) indexing so every position has equal
+    probability of being a block start.
+
+    Parameters
+    ----------
+    x:
+        1D input array to resample.
+    block_size:
+        Length of each contiguous block.
+    n_surrogates:
+        Number of surrogate samples to generate.
+    rng:
+        NumPy random Generator for reproducibility. If None, uses
+        numpy.random.default_rng().
+
+    Returns
+    -------
+    np.ndarray
+        Shape (n_surrogates, len(x)). Each row is one block-resampled surrogate.
+    """
+    raise NotImplementedError


### PR DESCRIPTION
Adds four files:
- itpu/stats/__init__.py: exports surrogate_test
- itpu/stats/surrogates.py: shuffle_surrogate, block_bootstrap_surrogate stubs
- itpu/stats/multiple_testing.py: benjamini_hochberg stub
- itpu/stats/surrogate_test.py: surrogate_test stub

All functions raise NotImplementedError. Docstrings describe the full
contract (parameters, return shape/type, algorithmic intent) so
implementations can proceed without revisiting the design.

https://claude.ai/code/session_01KnRgKPy11J7AECHpQBUksH