### PR TITLE
Add locked calibration and power tests for surrogate_test()

### DIFF
--- a/tests/test_surrogate_validation.py
+++ b/tests/test_surrogate_validation.py
@@ -1,0 +1,73 @@
+# LOCKED THRESHOLDS — see decision log 2026-04-19
+"""Validity tests for the surrogate_test() pipeline.
+
+These are validity tests, not smoke tests. They verify statistical
+properties of the surrogate testing procedure under known conditions:
+
+- test_h0_pvalue_calibration: Under the null (x and y independent
+  Gaussians), p-values returned by surrogate_test() must be uniformly
+  distributed on [0, 1]. Calibration is verified via a Kolmogorov-Smirnov
+  test against the uniform distribution.
+
+- test_h1_power_detects_correlation: Under a strong linear alternative
+  (rho=0.6), surrogate_test() must reject at p < 0.05.
+
+The KS threshold (pvalue > 0.05) and trial count (400) are locked and
+must not be adjusted post-hoc to make a failing calibration test pass.
+If the calibration test fails, the surrogate procedure is miscalibrated
+and surrogate_test() must be fixed, not the threshold.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from itpu.stats.surrogate_test import surrogate_test
+
+
+@pytest.mark.slow
+def test_h0_pvalue_calibration():
+    """P-values under H₀ must be uniformly distributed.
+
+    400 independent trials, each with n=1000 i.i.d. Gaussian x and y.
+    KS test against Uniform[0,1]: assert pvalue > 0.05.
+    LOCKED — do not adjust the threshold or trial count.
+    """
+    n_trials = 400
+    p_values = np.empty(n_trials)
+
+    for i in range(n_trials):
+        rng = np.random.default_rng(i)
+        x = rng.standard_normal(1000)
+        y = rng.standard_normal(1000)
+        result = surrogate_test(
+            x, y, method="ksg", n_surrogates=999, surrogate_type="shuffle"
+        )
+        p_values[i] = result["p_value"]
+
+    ks_result = stats.kstest(p_values, "uniform")
+    assert ks_result.pvalue > 0.05, (
+        f"P-values under H₀ are not uniform (KS pvalue={ks_result.pvalue:.4f}). "
+        "The surrogate procedure is miscalibrated."
+    )
+
+
+def test_h1_power_detects_correlation():
+    """Surrogate test must reject at p < 0.05 under strong linear dependence.
+
+    x ~ N(0,1), y = 0.6*x + 0.4*N(0,1), n=500, n_surrogates=499.
+    LOCKED — do not adjust the threshold or the correlation coefficient.
+    """
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal(500)
+    y = 0.6 * x + 0.4 * rng.standard_normal(500)
+
+    result = surrogate_test(
+        x, y, method="ksg", n_surrogates=499, surrogate_type="shuffle"
+    )
+
+    assert result["p_value"] < 0.05, (
+        f"Failed to detect strong correlation (p={result['p_value']:.4f}). "
+        "Expected p < 0.05 for rho=0.6 with n=500."
+    )


### PR DESCRIPTION
tests/test_surrogate_validation.py contains two human-specified validity
tests with locked numerical thresholds (see decision log 2026-04-19):

- test_h0_pvalue_calibration (marked slow): 400 independent H0 trials,
  n=1000 i.i.d. Gaussians each, KS test vs Uniform[0,1], assert pvalue > 0.05
- test_h1_power_detects_correlation: rho=0.6, n=500, n_surrogates=499,
  assert p_value < 0.05

Both tests currently raise NotImplementedError — correct state until
surrogate_test() is implemented. Module docstring explains that thresholds
must not be adjusted post-hoc to rescue a failing calibration test.

https://claude.ai/code/session_01KnRgKPy11J7AECHpQBUksH