### PR TITLE
Task 6: surrogate_test() implementation, SDK KSG fix, calibration verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### R1 Status — Surrogate Testing Framework: Complete (2026-04-20)
+
+**Delivered:**
+- `itpu/stats/` module: `surrogates.py`, `multiple_testing.py`, `surrogate_test.py`
+- `shuffle_surrogate` and `block_bootstrap_surrogate` with full test coverage
+- `benjamini_hochberg` with order-preservation correctness (12 tests)
+- `surrogate_test()` wired end-to-end through `ITPU` SDK
+- Locked calibration and power tests in `tests/test_surrogate_validation.py`
+
+**KSG calibration gate result (locked, on record):**
+- KS statistic: **0.0565** | KS p-value: **0.1497** — PASS (threshold > 0.05)
+- 400 independent H₀ trials, n=1000, n_surrogates=999, surrogate_type="shuffle"
+
+**Two bugs caught and fixed by the calibration gate (not the power test):**
+
+1. *Wrong metric in SDK shadow KSG implementation* — `sdk.py` contained a
+   duplicate `_mi_ksg` using Euclidean distance in the joint space instead of
+   Chebyshev (KSG-1 requirement). Fixed by wiring `ITPU.mutual_info(method="ksg")`
+   to delegate to `ksg_mi_estimate` in `kernels_sw/ksg.py` — one implementation,
+   correct metric. Pre-fix KS: 0.0785 / p=0.0137 (FAIL).
+
+2. *`max(mi, 0.0)` clipping breaking null distribution comparison* — Under H₀,
+   ~50% of KSG estimates are naturally negative. Clipping both observed and null
+   values to 0 caused p_value=1.0 whenever mi_observed clipped, producing a
+   bimodal p-value distribution (KS: 0.4850 / p=0.0000). Fixed by adding
+   `clip_zero=True` parameter to `ksg_mi_estimate` (default preserves all
+   existing callers); SDK passes `clip_zero=False`.
+
+Neither bug was catchable by the H₁ power test — ρ=0.6 is strong enough to
+survive both. The calibration gate is the reason they were caught before shipping.
+
+**Open items (Phase 2):**
+- IAAFT surrogate fast-follow (preserves power spectrum; needed for oscillatory data)
+- Batch FDR: `surrogate_test` accepts `fdr_alpha` but BH correction not yet applied in batch context
+- Adaptive k-selection for KSG (data-driven k rather than fixed k=5)
+- **SDK shadow implementation audit for `method="hist"` — confirmed open:** `sdk.py`'s
+  `_mi_hist` computes marginals from independent 1D histograms (inconsistent bin edges
+  vs joint); `kernels_sw/hist.py` correctly derives marginals by summing the joint
+  histogram. Same architectural problem as KSG. Fix: wire `ITPU.mutual_info(method="hist")`
+  to delegate to `mutual_info_hist` in `kernels_sw/hist.py`. Not blocking R1 (surrogate_test
+  defaults to `method="ksg"`) but must be resolved before hist-based surrogate testing.
+
 ### Added
 
 - Comprehensive benchmark suite comparing against SciPy/scikit-learn

--- a/itpu/kernels_sw/ksg.py
+++ b/itpu/kernels_sw/ksg.py
@@ -14,7 +14,7 @@ def _as_1d(a):
     return a
 
 def ksg_mi_estimate(
-    x, y, k: int = 5, metric: str = "chebyshev"
+    x, y, k: int = 5, metric: str = "chebyshev", clip_zero: bool = True
 ) -> tuple[float, dict]:
     """
     Kraskov–Stögbauer–Grassberger MI estimator (variant I).
@@ -62,7 +62,9 @@ def ksg_mi_estimate(
     nx = np.maximum(nx, 0); ny = np.maximum(ny, 0)
 
     mi = digamma(k) + digamma(N) - np.mean(digamma(nx + 1) + digamma(ny + 1))
-    mi = float(max(mi, 0.0))
+    if clip_zero:
+        mi = max(mi, 0.0)
+    mi = float(mi)
     stats = dict(N=N, k=k, metric=metric, method="ksg")
     return mi, stats
 

--- a/itpu/sdk.py
+++ b/itpu/sdk.py
@@ -33,7 +33,7 @@ class ITPU:
             return _mi_hist(x, y, bins=bins)
         elif method == "ksg":
             k = int(kwargs.get("k", 5))
-            mi, _ = ksg_mi_estimate(x, y, k=k)
+            mi, _ = ksg_mi_estimate(x, y, k=k, clip_zero=False)
             return mi
         else:
             raise ValueError(f"Unknown method: {method}")

--- a/itpu/sdk.py
+++ b/itpu/sdk.py
@@ -1,34 +1,10 @@
-# top of file
-from sklearn.neighbors import NearestNeighbors
-
-def _mi_ksg(x, y, k=5):
-    x = np.asarray(x).reshape(-1, 1)
-    y = np.asarray(y).reshape(-1, 1)
-    n = x.shape[0]
-    if n != y.shape[0]:
-        raise ValueError("x,y length mismatch")
-    if k <= 0 or k >= n:
-        raise ValueError("k must be in [1, n-1)")
-
-    xy = np.hstack([x, y])
-
-    # kNN in joint space with Chebyshev (∞) norm (KSG-1 requirement)
-    nn = NearestNeighbors(n_neighbors=k+1, metric="chebyshev", n_jobs=-1)
-    nn.fit(xy)
-    dists, _ = nn.kneighbors(xy, return_distance=True)
-    eps = dists[:, -1]  # k-th neighbor radius
-
-    nx = _count_within_radius_1d(x.ravel(), eps, strict=True)
-    ny = _count_within_radius_1d(y.ravel(), eps, strict=True)
-
-    from scipy.special import digamma  # prefer SciPy’s digamma
-    return float(np.mean(digamma(k) - digamma(nx + 1) - digamma(ny + 1) + digamma(n)))
-# itpu/sdk.py
 import numpy as np
-from math import log
 from scipy.spatial import cKDTree
 
+from itpu.kernels_sw.ksg import ksg_mi_estimate
+
 __all__ = ["ITPU"]
+
 
 class ITPU:
     """
@@ -57,13 +33,14 @@ class ITPU:
             return _mi_hist(x, y, bins=bins)
         elif method == "ksg":
             k = int(kwargs.get("k", 5))
-            return _mi_ksg(x, y, k=k)
+            mi, _ = ksg_mi_estimate(x, y, k=k)
+            return mi
         else:
             raise ValueError(f"Unknown method: {method}")
 
+
 # ---------- Histogram-based MI (nats) ----------
 def _entropy_from_hist(counts):
-    # counts: nonnegative, sum > 0
     p = counts.astype(float)
     total = p.sum()
     if total <= 0:
@@ -72,86 +49,14 @@ def _entropy_from_hist(counts):
     p = p[p > 0]
     return float(-(p * np.log(p)).sum())
 
+
 def _mi_hist(x, y, bins=64):
-    # 1D histograms
     hx, _ = np.histogram(x, bins=bins)
     hy, _ = np.histogram(y, bins=bins)
-    # 2D joint histogram
     hxy, _, _ = np.histogram2d(x, y, bins=bins)
 
     Hx = _entropy_from_hist(hx)
     Hy = _entropy_from_hist(hy)
-    Hxy = _entropy_from_hist(hxy)  # flatten ok in helper
+    Hxy = _entropy_from_hist(hxy)
 
     return Hx + Hy - Hxy
-
-# ---------- KSG (Kraskov-Stögbauer-Grassberger) MI (nats), variant 1 ----------
-# Minimal, dependency-light implementation for 1D x,y.
-# Uses Chebyshev (infinity) norm in joint space, digamma via scipy.special if available
-try:
-    from scipy.special import digamma
-except Exception:
-    # simple fallback: harmonic approximation
-    def digamma(n):
-        # Euler–Mascheroni gamma ~0.57721
-        if n <= 0:
-            raise ValueError("digamma requires n>0 in this fallback.")
-        return -0.5772156649015329 + sum(1.0/i for i in range(1, int(n)))
-
-def _mi_ksg(x, y, k=5):
-    """
-    KSG-1 estimator for continuous MI in nats.
-    """
-    x = np.asarray(x).reshape(-1, 1)
-    y = np.asarray(y).reshape(-1, 1)
-    n = x.shape[0]
-    if n != y.shape[0]:
-        raise ValueError("x,y length mismatch")
-    if k <= 0 or k >= n:
-        raise ValueError("k must be in [1, n-1)")
-
-    # Joint space with Chebyshev (max) norm via KDTree by duplicating dims and using max radius
-    xy = np.hstack([x, y])
-    tree_joint = cKDTree(xy)
-    # Distance to k-th neighbor in joint space (Chebyshev approximated by max of |dx|,|dy|)
-    # We emulate Chebyshev by querying in Euclidean but we will count marginals strictly less than eps.
-    # Query k+1 because point itself counts as neighbor.
-    dists, _ = tree_joint.query(xy, k=k+1, workers=-1)
-    eps = dists[:, -1]  # radius to k-th neighbor
-
-    # Count neighbors in marginals within strictly less than eps (avoid boundary double counts)
-    nx = _count_within_radius_1d(x, eps, strict=True)
-    ny = _count_within_radius_1d(y, eps, strict=True)
-
-    # KSG-1 formula (nats)
-    # I = psi(k) - <psi(nx+1)+psi(ny+1)> + psi(n)  (with digamma)
-    term = np.mean(digamma(k) - digamma(nx + 1) - digamma(ny + 1) + digamma(n))
-    return float(term)
-
-def _count_within_radius_1d(x, eps, strict=True):
-    """
-    For each point i, count number of other samples whose |x_j - x_i| < eps_i (strict) or <= eps_i.
-    Returns counts excluding the point itself.
-    """
-    x = np.asarray(x).ravel()
-    n = x.shape[0]
-    # Sort to enable sliding window counts
-    order = np.argsort(x)
-    xs = x[order]
-    counts = np.empty(n, dtype=int)
-
-    j_left = 0
-    for idx, i in enumerate(order):
-        xi = xs[idx]
-        # expand left boundary
-        while j_left < n and (xi - xs[j_left] > eps[i] if strict else xi - xs[j_left] >= eps[i]):
-            j_left += 1
-        # expand right boundary
-        j_right = idx + 1
-        while j_right < n and (xs[j_right] - xi < eps[i] if strict else xs[j_right] - xi <= eps[i]):
-            j_right += 1
-        # total in (left,right) minus 1 (exclude self)
-        counts[i] = (j_right - j_left) - 1
-    # clamp minimum 0
-    counts[counts < 0] = 0
-    return counts

--- a/itpu/stats/surrogate_test.py
+++ b/itpu/stats/surrogate_test.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
+from itpu.sdk import ITPU
+from itpu.stats.surrogates import block_bootstrap_surrogate, shuffle_surrogate
+
 
 def surrogate_test(
     x,
@@ -10,6 +15,7 @@ def surrogate_test(
     n_surrogates: int = 1000,
     surrogate_type: str = "shuffle",
     fdr_alpha: float = 0.05,
+    rng=None,
 ) -> dict[str, Any]:
     """Test for statistical dependence between x and y using surrogate resampling.
 
@@ -17,10 +23,6 @@ def surrogate_test(
     then builds a null distribution by computing MI between x and n_surrogates
     surrogate copies of y (generated via surrogate_type). The empirical p-value
     is the fraction of null MI values >= the observed MI.
-
-    Optionally applies Benjamini-Hochberg FDR correction when called in a
-    multi-test context (reserved for future batch interface; fdr_alpha is
-    stored in the returned dict for downstream use).
 
     Parameters
     ----------
@@ -36,8 +38,13 @@ def surrogate_test(
         Resampling strategy for generating surrogates. One of:
         "shuffle" (independent permutation) or "block" (block bootstrap).
     fdr_alpha:
-        FDR level passed to benjamini_hochberg() for downstream correction.
-        Not applied internally to the single-test p-value.
+        FDR level for downstream Benjamini-Hochberg correction. This parameter
+        is accepted for API compatibility with future batch usage but is NOT
+        applied internally — p_value is always the raw permutation p-value.
+        Batch FDR correction is a follow-on feature, not implemented here.
+    rng:
+        Seed or numpy Generator for reproducibility. Passed to the surrogate
+        generator. Default None produces non-deterministic results.
 
     Returns
     -------
@@ -45,14 +52,52 @@ def surrogate_test(
         mi_observed : float
             MI estimate (nats) between x and y.
         null_distribution : np.ndarray, shape (n_surrogates,)
-            MI values computed under the null (x independent of shuffled y).
+            MI values computed under the null (x vs shuffled y).
         p_value : float
-            Empirical p-value: fraction of null MI >= mi_observed.
+            Empirical permutation p-value:
+            (sum(null >= mi_observed) + 1) / (n_surrogates + 1).
+            This formula is locked — do not substitute an alternative.
         power_estimate : float
-            Estimated statistical power based on the separation between
-            mi_observed and the null distribution (heuristic, [0, 1]).
+            Proxy for power: proportion of null distribution below mi_observed,
+            i.e. mean(null < mi_observed). This is not a formal power analysis.
         warnings : list[str]
-            Any diagnostic messages raised during estimation (e.g. from
-            ksg_mi_estimate) collected and surfaced here.
+            Diagnostic messages. Contains one entry if mi_observed is below
+            the null mean (possible estimator bias or insufficient sample size).
     """
-    raise NotImplementedError
+    x = np.asarray(x).ravel()
+    y = np.asarray(y).ravel()
+
+    sdk = ITPU(device="software")
+    mi_observed = sdk.mutual_info(x, y, method=method)
+
+    if surrogate_type == "shuffle":
+        surrogates = shuffle_surrogate(y, n_surrogates=n_surrogates, rng=rng)
+    elif surrogate_type == "block":
+        block_size = max(1, len(x) // 20)
+        surrogates = block_bootstrap_surrogate(
+            y, block_size=block_size, n_surrogates=n_surrogates, rng=rng
+        )
+    else:
+        raise ValueError(f"Unknown surrogate_type: {surrogate_type!r}. Use 'shuffle' or 'block'.")
+
+    null_distribution = np.array([
+        sdk.mutual_info(x, surrogates[i], method=method)
+        for i in range(n_surrogates)
+    ])
+
+    p_value = (np.sum(null_distribution >= mi_observed) + 1) / (n_surrogates + 1)
+    power_estimate = float(np.mean(null_distribution < mi_observed))
+
+    warning_messages = []
+    if mi_observed < np.mean(null_distribution):
+        warning_messages.append(
+            "Observed MI below null mean — possible estimator bias or insufficient sample size."
+        )
+
+    return {
+        "mi_observed": float(mi_observed),
+        "null_distribution": null_distribution,
+        "p_value": float(p_value),
+        "power_estimate": power_estimate,
+        "warnings": warning_messages,
+    }


### PR DESCRIPTION
## Summary

- Implements `surrogate_test()` end-to-end
- Fixes two bugs caught by the calibration gate before anything shipped
- Updates CHANGELOG with R1 completion status and open items

## Changes

**`itpu/stats/surrogate_test.py`** — full implementation:
- `mi_observed` via `ITPU(device="software").mutual_info(x, y, method=method)`
- Null distribution from `shuffle_surrogate` or `block_bootstrap_surrogate` (block_size = max(1, len(x)//20))
- `p_value = (sum(null >= mi_observed) + 1) / (n_surrogates + 1)` — locked formula
- `power_estimate = mean(null < mi_observed)` — proxy only, documented
- `warnings` list populated when `mi_observed < mean(null)`
- `fdr_alpha` accepted for batch API compatibility; not applied for single calls
- `rng` parameter added for reproducibility

**`itpu/sdk.py`** — wired `method="ksg"` to delegate to `ksg_mi_estimate` from `kernels_sw/ksg.py`:
- Removes duplicate shadow `_mi_ksg` and `_count_within_radius_1d` (pure-Python O(n²) loop)
- Correct Chebyshev metric now used; same implementation as the kernel

**`itpu/kernels_sw/ksg.py`** — `clip_zero=True` parameter added:
- Default preserves all existing callers
- SDK passes `clip_zero=False` so surrogate null comparison uses unclipped values

## Two bugs caught by calibration gate (not catchable by H₁ power test)

ρ=0.6 is strong enough to survive both bugs — only the H₀ calibration check exposed them.

**Bug 1 — wrong metric:** SDK's shadow `_mi_ksg` used Euclidean distance in joint space (not Chebyshev as KSG-1 requires). Pre-fix KS: 0.0785 / p=0.0137 (FAIL).

**Bug 2 — clipping breaking null distribution:** `max(mi, 0.0)` in `ksg_mi_estimate` caused p_value=1.0 whenever mi_observed clipped from a negative estimate, producing bimodal p-values. Post-delegation KS: 0.4850 / p=0.0000 (catastrophic FAIL). Fixed by `clip_zero=False` in SDK path.

## Calibration result (locked, on record)

KS statistic: **0.0565** | KS p-value: **0.1497** — PASS (threshold > 0.05, locked)
400 H₀ trials × 999 surrogates, n=1000 i.i.d. Gaussians

## Test results

- `test_h1_power_detects_correlation` — PASS (p < 0.05 with ρ=0.6, n=500)
- `test_h0_pvalue_calibration` — PASS (KS p=0.1497, comfortable margin)

https://claude.ai/code/session_01KnRgKPy11J7AECHpQBUksH