### PR TITLE
Add ask_claude.py + README fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,3 +329,4 @@ playground/
 temp/
 tmp/
 profile_results.txt
+schematic_analysis.txt

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ tests/
   ...
 
 docs/
+  estimator_guide.md      # surrogate selection decision tree, histogram bias, KSG notes
   roadmap.md
   kernels.md
 ```
@@ -133,7 +134,7 @@ BCI/EEG real-time MI, medical imaging registration, causal ML. The hardware need
 ```bash
 pip install -e .
 pytest -q -m "not slow"   # fast suite — runs in ~10s
-pytest -q --slow          # includes H₀ calibration (400 trials, ~1hr)
+pytest -q -m slow         # includes H₀ calibration (400 trials, ~1hr)
 ```
 
 Public API stability contract: `ITPU.mutual_info()`, `windowed_mi()`, `surrogate_test()`. Add tests for new kernels. The calibration thresholds in `tests/test_surrogate_validation.py` are locked — if a code change fails calibration, fix the code, not the threshold.

--- a/ask_claude.py
+++ b/ask_claude.py
@@ -1,0 +1,137 @@
+"""Send the ITPU hardware schematic to Claude for architectural analysis.
+
+Usage:
+    python ask_claude.py [image_path]
+
+Defaults to the schematic PNG in the repo root.
+Streams the analysis to stdout and writes schematic_analysis.txt.
+Requires ANTHROPIC_API_KEY in the environment.
+"""
+import base64
+import sys
+from pathlib import Path
+
+import anthropic
+
+DEFAULT_IMAGE = Path(__file__).parent / "4F4F1C25-07C8-4C70-83E0-7CF0A892819F.PNG"
+
+SYSTEM_PROMPT = (
+    "You are an expert FPGA architect and information-theoretic systems designer "
+    "reviewing a hardware block diagram for the ITPU (Information-Theoretic Processing Unit).\n\n"
+    "Context:\n"
+    "- ITPU is a dedicated silicon accelerator for mutual information, entropy, and k-NN "
+    "statistics — workloads that are branch-heavy, memory-bound, and poorly suited to "
+    "matrix-multiply hardware.\n"
+    "- The software SDK ships first (Python, tested and calibrated). The FPGA pathfinder "
+    "(R2) is next; the silicon target is R3.\n"
+    "- Three core kernels, with measured software performance baselines:\n"
+    "    1. KSG (Kraskov–Stögbauer–Grassberger) k-NN MI: 230 ns/sample target\n"
+    "    2. Histogram MI: 150 ns/sample target\n"
+    "    3. IAAFT surrogate generation: 1.2 µs/surrogate target\n"
+    "- The software stack uses: Chebyshev (L∞) metric for KSG k-NN search, rfft/irfft "
+    "for IAAFT, and 2D histogram binning for MI. These must map cleanly to hardware primitives.\n"
+    "- The permutation p-value formula is locked: p = (#{null ≥ observed} + 1) / (n + 1). "
+    "Hardware must preserve this exact arithmetic.\n"
+    "- Target domains: BCI/EEG real-time MI, medical imaging registration, causal ML.\n\n"
+    "Your role: review the schematic with the eye of someone who will eventually tape this out. "
+    "Be direct about design quality, bottlenecks, and risks."
+)
+
+USER_PROMPT = (
+    "Please analyze this ITPU FPGA architecture schematic. I want your honest assessment on:\n\n"
+    "1. **Pipeline throughput** — Do the proposed datapath widths and clock domains support "
+    "the KSG (230 ns), Histogram (150 ns), and IAAFT (1.2 µs) targets? Where are the "
+    "throughput ceilings?\n\n"
+    "2. **Memory bandwidth** — What are the on-chip SRAM and off-chip DRAM bandwidth "
+    "requirements? Are there obvious bandwidth bottlenecks for the k-NN search or FFT stages?\n\n"
+    "3. **Clock domain and timing** — Are there concerning CDC (clock domain crossing) "
+    "boundaries? Is the pipeline depth reasonable for timing closure at the target frequency?\n\n"
+    "4. **Kernel-to-hardware mapping** — How well does the schematic map to the three "
+    "software kernels (Chebyshev k-NN, histogram accumulation, rfft/irfft)? Are there "
+    "structural mismatches that will require algorithmic changes?\n\n"
+    "5. **R2 pathfinder readiness** — What would you change before committing this to an "
+    "FPGA development board? What are the one or two highest-risk items that could sink R2?\n\n"
+    "Be specific. Point to structures in the diagram when you can."
+)
+
+
+def main(image_path: Path) -> None:
+    if not image_path.exists():
+        print(f"Error: image not found: {image_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(image_path, "rb") as f:
+        image_data = base64.standard_b64encode(f.read()).decode("utf-8")
+
+    client = anthropic.Anthropic()
+
+    print(f"Image: {image_path.name}")
+    print(f"Model: claude-opus-4-7  |  thinking: adaptive  |  effort: high")
+    print("=" * 72)
+
+    text_chunks: list[str] = []
+    in_thinking = False
+
+    with client.messages.stream(
+        model="claude-opus-4-7",
+        max_tokens=16000,
+        thinking={"type": "adaptive", "display": "summarized"},
+        output_config={"effort": "high"},
+        system=[
+            {
+                "type": "text",
+                "text": SYSTEM_PROMPT,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": image_data,
+                        },
+                    },
+                    {"type": "text", "text": USER_PROMPT},
+                ],
+            }
+        ],
+    ) as stream:
+        for event in stream:
+            if event.type == "content_block_start":
+                if event.content_block.type == "thinking":
+                    print("\n[Thinking]\n", flush=True)
+                    in_thinking = True
+                elif event.content_block.type == "text":
+                    if in_thinking:
+                        print("\n[Analysis]\n", flush=True)
+                    in_thinking = False
+            elif event.type == "content_block_delta":
+                if event.delta.type == "thinking_delta":
+                    print(event.delta.thinking, end="", flush=True)
+                elif event.delta.type == "text_delta":
+                    print(event.delta.text, end="", flush=True)
+                    text_chunks.append(event.delta.text)
+        final = stream.get_final_message()
+
+    print("\n" + "=" * 72)
+
+    u = final.usage
+    print(f"\nUsage:")
+    print(f"  input_tokens:                {u.input_tokens:,}")
+    print(f"  cache_creation_input_tokens: {u.cache_creation_input_tokens:,}")
+    print(f"  cache_read_input_tokens:     {u.cache_read_input_tokens:,}")
+    print(f"  output_tokens:               {u.output_tokens:,}")
+
+    out_path = Path(__file__).parent / "schematic_analysis.txt"
+    out_path.write_text("".join(text_chunks), encoding="utf-8")
+    print(f"\nAnalysis written to {out_path.name}")
+
+
+if __name__ == "__main__":
+    image_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_IMAGE
+    main(image_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
   "sphinx>=4.0.0",
   "sphinx-rtd-theme>=1.0.0",
   "myst-parser>=0.17.0",
+  "anthropic>=0.40.0",
 ]
 demos = [
   "notebook>=6.4.0",


### PR DESCRIPTION
## Summary

- **`ask_claude.py`** — sends the ITPU FPGA hardware schematic to Claude Opus 4.7 for architectural analysis. Uses streaming, adaptive thinking (`display: summarized`), `effort: high`, and prompt caching on the ITPU system prompt. Writes the text analysis to `schematic_analysis.txt` (gitignored). Accepts an optional image path argument; defaults to the schematic PNG in the repo root.
- **`pyproject.toml`** — adds `anthropic>=0.40.0` to `[dev]` extras so `pip install -e ".[dev]"` covers the script's dependency.
- **`README.md`** — fixes two stale entries: `pytest -q --slow` → `pytest -q -m slow` (the old form errors), and adds `docs/estimator_guide.md` to the repository layout section (referenced in the surrogate testing notes but previously missing from the tree).
- **`.gitignore`** — adds `schematic_analysis.txt` alongside the existing `profile_results.txt` entry.

## Test plan

- [ ] CI passes on ubuntu / py3.10 + py3.11 (`pytest -q -m "not slow"`, 46 tests)
- [ ] `python -m pytest -q -m slow` collects exactly 1 test (H₀ calibration)
- [ ] `python ask_claude.py` runs end-to-end with `ANTHROPIC_API_KEY` set, streams analysis, writes `schematic_analysis.txt`

https://claude.ai/code/session_01KnRgKPy11J7AECHpQBUksH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnRgKPy11J7AECHpQBUksH)_